### PR TITLE
fixed the test in PGConnectionTLSTest

### DIFF
--- a/src/main/java/org/postgresql/sql2/execution/DefaultNioLoop.java
+++ b/src/main/java/org/postgresql/sql2/execution/DefaultNioLoop.java
@@ -186,8 +186,10 @@ public class DefaultNioLoop implements NioLoop, Runnable {
 
     @Override
     public void writeRequired() {
-      this.selectionKey.interestOps(this.selectionKey.interestOps() | SelectionKey.OP_WRITE);
-      DefaultNioLoop.this.selector.wakeup();
+      if (selectionKey.isValid()) {
+        this.selectionKey.interestOps(this.selectionKey.interestOps() | SelectionKey.OP_WRITE);
+        DefaultNioLoop.this.selector.wakeup();
+      }
     }
 
     @Override


### PR DESCRIPTION
What I think happens is that the server closes the tcp connection before we manage to read the error packet from the server, that makes the attempt to write to the socket throw an exception.

So by checking if the selection key is valid before we try to write, we can avoid this exception being thrown.